### PR TITLE
商品詳細表示機能

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -18,6 +18,10 @@ class ItemsController < ApplicationController
     end
   end
 
+  def show
+    @item = Item.find(params[:id])
+  end
+
   private
 
   def items_params

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,8 +1,8 @@
 class ItemsController < ApplicationController
   before_action :authenticate_user!, only: [:new, :create]
-  
+
   def index
-    @items = Item.all.order("created_at DESC")
+    @items = Item.all.order('created_at DESC')
   end
 
   def new

--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -1,5 +1,4 @@
 class OrdersController < ApplicationController
-
   def index
     @orders = Order.all
   end

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -129,7 +129,7 @@
       <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
       <% @items.each do |item| %>
           <li class='list'>
-            <%= link_to "#" do %>
+            <%= link_to item_path(item) do %>
             <div class='item-img-content'>
               <%= image_tag item.image , class: "item-img" %>
               <%# 商品が売れていればsold outを表示しましょう %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -29,9 +29,11 @@
     <p class='or-text'>or</p>
     <%= link_to '削除', "#", method: :delete, class:'item-destroy' %>
 
-    <%# 商品が売れていない場合はこちらを表示しましょう %>
+    <%# unless item.order%>
+    <%# 商品が売れていない場合はこちらを表示する %>
     <%= link_to '購入画面に進む', "#" ,class:"item-red-btn"%>
-    <%# //商品が売れていない場合はこちらを表示しましょう %>
+    <%# //商品が売れていない場合はこちらを表示する %>
+    <%# end %>
 
 
     <% end  %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -16,7 +16,7 @@
     </div>
     <div class="item-price-box">
       <span class="item-price">
-        ¥ 999,999,999
+        ¥ <%= @item.price %>
       </span>
       <span class="item-postage">
         <%= '配送料負担' %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -47,27 +47,27 @@
       <tbody>
         <tr>
           <th class="detail-item">出品者</th>
-          <td class="detail-value"><%= "出品者名" %></td>
+          <td class="detail-value"><%= @item.user.nickname %></td>
         </tr>
         <tr>
           <th class="detail-item">カテゴリー</th>
-          <td class="detail-value"><%= "カテゴリー名" %></td>
+          <td class="detail-value"><%= @item.category.category_name %></td>
         </tr>
         <tr>
           <th class="detail-item">商品の状態</th>
-          <td class="detail-value"><%= "商品の状態" %></td>
+          <td class="detail-value"><%= @item.condition.condition %></td>
         </tr>
         <tr>
           <th class="detail-item">配送料の負担</th>
-          <td class="detail-value"><%= "発送料の負担" %></td>
+          <td class="detail-value"><%= @item.shipping_fee.paid_by %></td>
         </tr>
         <tr>
           <th class="detail-item">発送元の地域</th>
-          <td class="detail-value"><%= "発送元の地域" %></td>
+          <td class="detail-value"><%= @item.prefecture.name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送日の目安</th>
-          <td class="detail-value"><%= "発送日の目安" %></td>
+          <td class="detail-value"><%= @item.days_ship.how_many_days %></td>
         </tr>
       </tbody>
     </table>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -4,7 +4,7 @@
 <div class="item-show">
   <div class="item-box">
     <h2 class="name">
-      <%= "商品名" %>
+      <%= @item.name %>
     </h2>
     <div class='item-img-content'>
       <%= image_tag @item.image ,class:"item-box-img" %>
@@ -19,7 +19,7 @@
         ¥ <%= @item.price %>
       </span>
       <span class="item-postage">
-        <%= '配送料負担' %>
+        <%=  @item.shipping_fee.paid_by %>
       </span>
     </div>
 
@@ -41,7 +41,7 @@
   
 
     <div class="item-explain-box">
-      <span><%= "商品説明" %></span>
+      <span><%= @item.description %></span>
     </div>
     <table class="detail-table">
       <tbody>
@@ -106,7 +106,7 @@
       後ろの商品 ＞
     </a>
   </div>
-  <a href="#" class='another-item'><%= "商品のカテゴリー名" %>をもっと見る</a>
+  <a href="#" class='another-item'><%= @item.category.category_name %>をもっと見る</a>
 </div>
 
 <%= render "shared/footer" %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -7,7 +7,7 @@
       <%= "商品名" %>
     </h2>
     <div class='item-img-content'>
-      <%= image_tag "item-sample.png" ,class:"item-box-img" %>
+      <%= image_tag @item.image ,class:"item-box-img" %>
       <%# if item.order%>
       <div class='sold-out'>
         <span>Sold Out!!</span>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -4,7 +4,7 @@
 <div class="item-show">
   <div class="item-box">
     <h2 class="name">
-      <%= @item.name %>
+      <%= @item.item_name %>
     </h2>
     <div class='item-img-content'>
       <%= image_tag @item.image ,class:"item-box-img" %>
@@ -23,23 +23,18 @@
       </span>
     </div>
 
-    <% if user_signed_in? && @item.user_id == current_user.id %>
-
-    <%= link_to '商品の編集', "#", method: :get, class: "item-red-btn" %>
-    <p class='or-text'>or</p>
-    <%= link_to '削除', "#", method: :delete, class:'item-destroy' %>
-
-    <% end  %>
-
-    <%# unless item.order%>
-      <% if user_signed_in? && @item.user_id != current_user.id %>
-      <%= link_to '購入画面に進む', "#" ,class:"item-red-btn"%>
+    <%# unless @item.order %>
+      <% if user_signed_in?%>
+        <% if @item.user_id == current_user.id %>
+            <%= link_to '商品の編集', "#", method: :get, class: "item-red-btn" %> 
+              <p class='or-text'>or</p>
+            <%= link_to '削除', "#", method: :delete, class:'item-destroy' %>
+          <% else %>
+            <%= link_to '購入画面に進む', "#" ,class:"item-red-btn"%>
+          <% end %>
       <% end %>
     <%# end %>
-
-
-  
-
+    
     <div class="item-explain-box">
       <span><%= @item.description %></span>
     </div>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -23,7 +23,7 @@
       </span>
     </div>
 
-    <%# ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
+    <% if user_signed_in? && @item.user_id == current_user.id %>
 
     <%= link_to '商品の編集', "#", method: :get, class: "item-red-btn" %>
     <p class='or-text'>or</p>
@@ -34,7 +34,7 @@
     <%# //商品が売れていない場合はこちらを表示しましょう %>
 
 
-    <%# //ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
+    <% end  %>
 
     <div class="item-explain-box">
       <span><%= "商品説明" %></span>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -32,9 +32,9 @@
     <% end  %>
 
     <%# unless item.order%>
-    <% if user_signed_in? && @item.user_id != current_user.id %>
-    <%= link_to '購入画面に進む', "#" ,class:"item-red-btn"%>
-    <% end %>
+      <% if user_signed_in? && @item.user_id != current_user.id %>
+      <%= link_to '購入画面に進む', "#" ,class:"item-red-btn"%>
+      <% end %>
     <%# end %>
 
 

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -29,6 +29,8 @@
     <p class='or-text'>or</p>
     <%= link_to '削除', "#", method: :delete, class:'item-destroy' %>
 
+    <% end  %>
+
     <%# unless item.order%>
     <%# 商品が売れていない場合はこちらを表示する %>
     <%= link_to '購入画面に進む', "#" ,class:"item-red-btn"%>
@@ -36,7 +38,7 @@
     <%# end %>
 
 
-    <% end  %>
+  
 
     <div class="item-explain-box">
       <span><%= "商品説明" %></span>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -32,9 +32,9 @@
     <% end  %>
 
     <%# unless item.order%>
-    <%# 商品が売れていない場合はこちらを表示する %>
+    <% if user_signed_in? && @item.user_id != current_user.id %>
     <%= link_to '購入画面に進む', "#" ,class:"item-red-btn"%>
-    <%# //商品が売れていない場合はこちらを表示する %>
+    <% end %>
     <%# end %>
 
 

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -8,11 +8,11 @@
     </h2>
     <div class='item-img-content'>
       <%= image_tag "item-sample.png" ,class:"item-box-img" %>
-      <%# 商品が売れている場合は、sold outを表示しましょう %>
+      <%# if item.order%>
       <div class='sold-out'>
         <span>Sold Out!!</span>
       </div>
-      <%# //商品が売れている場合は、sold outを表示しましょう %>
+      <%# end %>
     </div>
     <div class="item-price-box">
       <span class="item-price">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,6 @@
 Rails.application.routes.draw do
   devise_for :users
   root to: "items#index"
-  resources :items, only: [:new, :create]
+  resources :items, only: [:new, :create, :show]
   resources :orders, only: [:index, :create]
 end

--- a/spec/factories/addresses.rb
+++ b/spec/factories/addresses.rb
@@ -1,5 +1,4 @@
 FactoryBot.define do
   factory :address do
-    
   end
 end

--- a/spec/factories/addresses.rb
+++ b/spec/factories/addresses.rb
@@ -1,4 +1,0 @@
-FactoryBot.define do
-  factory :address do
-  end
-end

--- a/spec/factories/categories.rb
+++ b/spec/factories/categories.rb
@@ -1,4 +1,0 @@
-FactoryBot.define do
-  factory :category do
-  end
-end

--- a/spec/factories/conditions.rb
+++ b/spec/factories/conditions.rb
@@ -1,4 +1,0 @@
-FactoryBot.define do
-  factory :condition do
-  end
-end

--- a/spec/factories/days_ships.rb
+++ b/spec/factories/days_ships.rb
@@ -1,4 +1,0 @@
-FactoryBot.define do
-  factory :days_ship do
-  end
-end

--- a/spec/factories/order_addresses.rb
+++ b/spec/factories/order_addresses.rb
@@ -1,5 +1,4 @@
 FactoryBot.define do
   factory :order_address do
-    
   end
 end

--- a/spec/factories/order_addresses.rb
+++ b/spec/factories/order_addresses.rb
@@ -1,4 +1,0 @@
-FactoryBot.define do
-  factory :order_address do
-  end
-end

--- a/spec/factories/orders.rb
+++ b/spec/factories/orders.rb
@@ -1,5 +1,4 @@
 FactoryBot.define do
   factory :order do
-    
   end
 end

--- a/spec/factories/orders.rb
+++ b/spec/factories/orders.rb
@@ -1,4 +1,0 @@
-FactoryBot.define do
-  factory :order do
-  end
-end

--- a/spec/factories/prefectures.rb
+++ b/spec/factories/prefectures.rb
@@ -1,4 +1,0 @@
-FactoryBot.define do
-  factory :prefecture do
-  end
-end

--- a/spec/factories/shipping_fees.rb
+++ b/spec/factories/shipping_fees.rb
@@ -1,4 +1,0 @@
-FactoryBot.define do
-  factory :shipping_fee do
-  end
-end

--- a/spec/requests/orders_request_spec.rb
+++ b/spec/requests/orders_request_spec.rb
@@ -1,5 +1,4 @@
 require 'rails_helper'
 
-RSpec.describe "Orders", type: :request do
-
+RSpec.describe 'Orders', type: :request do
 end


### PR DESCRIPTION
# What
## 実装内容
### ログアウト状態でも商品詳細ページを閲覧できること
ルーティングを設定し、` item_path(:id) `を設定。link_toでshowページに遷移するように設定。

### 出品者にしか商品の編集・削除のリンクが踏めないようになっていること
` if user_signed_in? && @item.user_id == current_user.id `でサインインかつ、idが統一の場合にのみ子要素を表示

### 出品者以外（且つログインしたユーザー）のみ商品購入のリンクが踏めること
` unless item.order `でitemがorderを持っていない時 ＝ 返り値がfalseの時に子要素を表示する

### 商品出品時に登録した情報が見られるようになっていること
各情報を `item.`からの紐付けで表示できるようにする

### 画像が表示されており、画像がリンク切れなどになっていないこと（Herokuの仕様による画像のリンク切れは、要件未達に含まれない。デプロイのタスクにあるとおり、Heroku上では一定時間経過すると画像が消える。）
` @item.image `でレコードに紐付けされている画像データを表示する